### PR TITLE
fix: strip HTML tags from headings

### DIFF
--- a/layouts/partials/search/functions/parse-headings.html
+++ b/layouts/partials/search/functions/parse-headings.html
@@ -2,7 +2,7 @@
 {{- range .Fragments.HeadingsMap }}
   {{- $headings = $headings | append (dict
     "anchor" .ID
-    "title" (.Title | htmlUnescape))
+    "title" (.Title | plainify))
   }}
 {{- end }}
 {{- return $headings -}}


### PR DESCRIPTION
Fixes #152 