### PR TITLE
feat: do not save history to client if search.histories parameter is `false` (#217)

### DIFF
--- a/assets/search/js/form.ts
+++ b/assets/search/js/form.ts
@@ -302,7 +302,9 @@ export default class Form {
         engine.search(query, sorting, lang, years, taxonomies).then(({ results, time }) => {
             this.renderer.render(query, results, time)
         }).finally(() => {
-            Historiographer.save(query)
+            if (params.histories) {
+                Historiographer.save(query)
+            }
             this.spinner.hide()
         })
     }


### PR DESCRIPTION
v0.12.0 introduced the `histories` parameter which disables _loading_ and displaying the search history.
Although the history is still saved to the client, which might not be wanted (and unnecessary).