### PR TITLE
fix: show ancestors of headings

### DIFF
--- a/assets/search/js/renderer.ts
+++ b/assets/search/js/renderer.ts
@@ -345,11 +345,15 @@ export default class Renderer {
                     continue
                 }
 
-                headings += `<a title="${heading.title} - ${result.item.title}" href="${result.item.url}#${heading.anchor}" class="search-result search-result-heading">
+                let ancestors = this.headingAncestors(result.item.headings, heading.pid)
+                ancestors = ancestors.concat(result.item.title)
+                const subtitle = ancestors.join(' · ')
+                
+                headings += `<a title="${heading.title} - ${subtitle}" href="${result.item.url}#${heading.anchor}" class="search-result search-result-heading">
   <div class="search-result-icon search-result-heading-icon">${params.icons['heading']}</div>
   <div class="search-result-content">
     <div class="search-result-title">${this.highlight(heading.title, [matches[j]])}</div>
-    <div class="search-result-desc">${result.item.title}</div>
+    <div class="search-result-desc">${subtitle}</div>
   </div>
 </a>`
                 break // avoid match same heading multiple times.
@@ -357,5 +361,14 @@ export default class Renderer {
         }
 
         return headings
+    }
+
+    headingAncestors(headings, pid): Array<string> {
+        let v :Array<string> = []
+        if (pid >= 0) {
+            v.push(headings[pid].title)
+            v = v.concat(this.headingAncestors(headings, headings[pid].pid))
+        }
+        return v
     }
 }

--- a/layouts/partials/search/functions/parse-headings.html
+++ b/layouts/partials/search/functions/parse-headings.html
@@ -1,10 +1,5 @@
 {{- $headings := slice }}
 {{- with .Fragments }}
-  {{- range .HeadingsMap }}
-    {{- $headings = $headings | append (dict
-      "anchor" .ID
-      "title" (.Title | plainify))
-    }}
-  {{- end }}
+  {{- $headings = partial "search/functions/walk-headings" (dict "Headings" .Headings "PID" -1) }}
 {{- end }}
 {{- return $headings -}}

--- a/layouts/partials/search/functions/walk-headings.html
+++ b/layouts/partials/search/functions/walk-headings.html
@@ -1,0 +1,16 @@
+{{- $v := slice }}
+{{- $pid := .PID }}
+{{- range .Headings }}
+  {{- if ne .Title "" }}
+    {{- $v = $v | append (dict
+      "pid" $pid
+      "anchor" .ID
+      "title" (.Title | plainify))
+    }}
+  {{- end }}
+  {{- $v = $v | append (partial "search/functions/walk-headings" (dict
+    "Headings" .Headings
+    "PID" (add $pid (len $v))))
+  }}
+{{- end }}
+{{- return $v }}


### PR DESCRIPTION
Closes #249

With this patch, the headings with the same name will display their ancestors.

![image](https://github.com/user-attachments/assets/cd66ba10-0843-4d20-9d00-0a779a773d90)
